### PR TITLE
Show total earnings on lease orders

### DIFF
--- a/LaptopRentalManagement.BLL/Interfaces/IOrderService.cs
+++ b/LaptopRentalManagement.BLL/Interfaces/IOrderService.cs
@@ -27,5 +27,7 @@ namespace LaptopRentalManagement.BLL.Interfaces
         Task<bool> UpdateOrderPaymentStatusAsync(string zaloPayTransactionId, string status);
         Task<Order?> GetOrderByZaloPayTransactionIdAsync(string transactionId);
         Task<Order?> GetOrderEntityByIdAsync(int orderId);
+
+        Task<decimal> GetCompletedRevenueAsync(int ownerId);
     }
 }

--- a/LaptopRentalManagement.BLL/Services/OrderService.cs
+++ b/LaptopRentalManagement.BLL/Services/OrderService.cs
@@ -326,5 +326,10 @@ namespace LaptopRentalManagement.BLL.Services
         {
             return await _orderRepository.GetByIdAsync(orderId);
         }
+
+        public async Task<decimal> GetCompletedRevenueAsync(int ownerId)
+        {
+            return await _orderRepository.GetCompletedRevenueAsync(ownerId);
+        }
     }
 }

--- a/LaptopRentalManagement.DAL/Interfaces/IOrderRepository.cs
+++ b/LaptopRentalManagement.DAL/Interfaces/IOrderRepository.cs
@@ -18,6 +18,8 @@ namespace LaptopRentalManagement.DAL.Interfaces
 		
 		// ZaloPay methods
 		Task<Order?> GetByZaloPayTransactionIdAsync(string transactionId);
-		Task UpdateZaloPayTransactionIdAsync(int orderId, string transactionId);
-	}
+        Task UpdateZaloPayTransactionIdAsync(int orderId, string transactionId);
+
+        Task<decimal> GetCompletedRevenueAsync(int ownerId);
+    }
 }

--- a/LaptopRentalManagement.DAL/Repositories/OrderRepository.cs
+++ b/LaptopRentalManagement.DAL/Repositories/OrderRepository.cs
@@ -107,5 +107,12 @@ namespace LaptopRentalManagement.DAL.Repositories
                 await _context.SaveChangesAsync();
             }
         }
-	}
+
+        public async Task<decimal> GetCompletedRevenueAsync(int ownerId)
+        {
+            return await _context.Orders
+                .Where(o => o.OwnerId == ownerId && o.Status == "Completed")
+                .SumAsync(o => o.TotalCharge * 0.8m);
+        }
+        }
 }

--- a/LaptopRentalManagement/Pages/User/Lease-order/Index.cshtml
+++ b/LaptopRentalManagement/Pages/User/Lease-order/Index.cshtml
@@ -21,7 +21,11 @@
 		{
 			<!-- Order Status -->
 			<div class="col-md-9">
-				<h3 class="mb-4">Your Lease Order</h3>
+                                <h3 class="mb-4">Your Lease Order</h3>
+                                <div class="alert alert-info" role="alert">
+                                    Total Earnings (Completed Orders):
+                                    <strong>@Model.TotalRevenue.ToString("N0")₫</strong>
+                                </div>
 
 				<!-- Button trigger modal -->
 				<div class="tab-pane fade show active" id="buy-tab-pane" role="tabpanel">

--- a/LaptopRentalManagement/Pages/User/Lease-order/Index.cshtml.cs
+++ b/LaptopRentalManagement/Pages/User/Lease-order/Index.cshtml.cs
@@ -1,8 +1,6 @@
 ﻿using LaptopRentalManagement.BLL.DTOs.Request;
 using LaptopRentalManagement.BLL.DTOs.Response;
 using LaptopRentalManagement.BLL.Interfaces;
-using LaptopRentalManagement.BLL.Services;
-using LaptopRentalManagement.DAL.Entities;
 using LaptopRentalManagement.Model.DTOs.Request;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -21,6 +19,8 @@ namespace LaptopRentalManagement.Pages.User.Lease_order
 			_orderService = orderService;
 		}
         public IList<OrderResponse> MyLeaseOrder { get; set; } = new List<OrderResponse>();
+
+        public decimal TotalRevenue { get; set; }
         public async Task<IActionResult> OnGet()
         {
             var userIdClaim = User.FindFirstValue(ClaimTypes.NameIdentifier) ?? User.FindFirstValue("AccountId");
@@ -35,6 +35,9 @@ namespace LaptopRentalManagement.Pages.User.Lease_order
             };
 
             MyLeaseOrder = await _orderService.GetAllAsync(orderFilter);
+
+            TotalRevenue = await _orderService.GetCompletedRevenueAsync(userId);
+
             return Page();
         }
     }


### PR DESCRIPTION
## Summary
- compute total revenue for completed lease orders through service layer
- expose revenue calculation via new repository and service methods
- use service in razor page to display revenue

## Testing
- `dotnet build LaptopRentalManagement.sln -c Release` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688843ed24d8832088a0cea6306a5df3