### PR TITLE
Show delivery/return buttons based on rental dates

### DIFF
--- a/LaptopRentalManagement/Pages/User/Lease-order/Detail.cshtml
+++ b/LaptopRentalManagement/Pages/User/Lease-order/Detail.cshtml
@@ -7,10 +7,12 @@
 	var status = Model.Order?.Status ?? "Unknown";
 
 	var slotDates = Model.Order.Slots.Select(s => s.SlotDate).OrderBy(d => d).ToList();
-	var start = slotDates.FirstOrDefault();
-	var end = slotDates.LastOrDefault();
-	var totalDays = slotDates.Count;
-	var isRenting = status == "Renting";
+        var start = slotDates.FirstOrDefault();
+        var end = slotDates.LastOrDefault();
+        var totalDays = slotDates.Count;
+        var isRenting = status == "Renting";
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var canStartDelivery = status == "Approved" && today >= start;
         var currentStep = status switch
         {
                 "Unpaid" => 1,
@@ -64,13 +66,20 @@
 							</form>
 							break;
 
-						case "Approved":
-							<form method="post" asp-page-handler="Delivering" asp-route-orderId="@Model.Order.OrderId" asp-route-id="@Model.Order.Laptop.LaptopId" class="d-inline">
-								<button type="submit" class="btn btn-sm btn-warning">
-									<i class="fas fa-truck me-1"></i>Start Delivery
-								</button>
-							</form>
-							break;
+                                                case "Approved":
+                                                        @if (canStartDelivery)
+                                                        {
+                                                                <form method="post" asp-page-handler="Delivering" asp-route-orderId="@Model.Order.OrderId" asp-route-id="@Model.Order.Laptop.LaptopId" class="d-inline">
+                                                                        <button type="submit" class="btn btn-sm btn-warning">
+                                                                                <i class="fas fa-truck me-1"></i>Start Delivery
+                                                                        </button>
+                                                                </form>
+                                                        }
+                                                        else
+                                                        {
+                                                                <span class="text-muted">Awaiting rental date</span>
+                                                        }
+                                                        break;
 
 						case "Delivering":
 							<form method="post" asp-page-handler="Delivered" asp-route-orderId="@Model.Order.OrderId" asp-route-id="@Model.Order.Laptop.LaptopId" class="d-inline">

--- a/LaptopRentalManagement/Pages/User/Rental-order/Detail.cshtml
+++ b/LaptopRentalManagement/Pages/User/Rental-order/Detail.cshtml
@@ -7,11 +7,13 @@
 	var status = Model.Order?.Status ?? "Unknown";
 
 	var slotDates = Model.Order.Slots.Select(s => s.SlotDate).OrderBy(d => d).ToList();
-	var start = slotDates.FirstOrDefault();
-	var end = slotDates.LastOrDefault();
-	var totalDays = slotDates.Count;
-	var isRenting = status == "Renting";
-	var currentStep = status switch
+        var start = slotDates.FirstOrDefault();
+        var end = slotDates.LastOrDefault();
+        var totalDays = slotDates.Count;
+        var isRenting = status == "Renting";
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var canConfirmReturn = isRenting && today >= end.AddDays(1);
+        var currentStep = status switch
 	{
 		"Pending" => 1,
 		"Approved" => 2,
@@ -47,16 +49,16 @@
 				<h5 class="fw-bold mb-0">Order Progress</h5>
 
 
-				<div class="d-flex gap-2">
-					@if (isRenting)
-					{
-						<!-- Nút xác nhận đã trả -->
-						<form method="post" asp-page-handler="ConfirmReturn" asp-route-orderId="@Model.Order.OrderId">
-							<button type="submit" class="btn btn-success btn-sm">
-								<i class="fas fa-check-circle me-1"></i> Confirm Return
-							</button>
-						</form>
-					}
+                                <div class="d-flex gap-2">
+                                        @if (canConfirmReturn)
+                                        {
+                                                <!-- Nút xác nhận đã trả -->
+                                                <form method="post" asp-page-handler="ConfirmReturn" asp-route-orderId="@Model.Order.OrderId">
+                                                        <button type="submit" class="btn btn-success btn-sm">
+                                                                <i class="fas fa-check-circle me-1"></i> Confirm Return
+                                                        </button>
+                                                </form>
+                                        }
 					<!-- Nút khiếu nại -->
 					<button type="button" class="btn btn-outline-primary btn-sm" data-bs-toggle="modal" data-bs-target="#ticketModal">
 						<i class="fas fa-life-ring me-1"></i> Send ticket


### PR DESCRIPTION
## Summary
- hide the Start Delivery button until the first rental slot date
- hide the Confirm Return button until the day after the last slot

## Testing
- `dotnet build LaptopRentalManagement.sln`

------
https://chatgpt.com/codex/tasks/task_e_6888a011a7c8832093a3d0c912055218