### PR TITLE
Implement order sorting and status filtering

### DIFF
--- a/LaptopRentalManagement.DAL/Repositories/OrderRepository.cs
+++ b/LaptopRentalManagement.DAL/Repositories/OrderRepository.cs
@@ -64,12 +64,13 @@ namespace LaptopRentalManagement.DAL.Repositories
 			if (orderFilter.LaptopId.HasValue)
 				query = query.Where(o => o.LaptopId == orderFilter.LaptopId.Value);
 
-			return await query
-				.Include(o => o.Laptop)
-				.Include(o => o.Owner)
-				.Include(o => o.Renter)
-				.ToListAsync();
-		}
+                        return await query
+                                .Include(o => o.Laptop)
+                                .Include(o => o.Owner)
+                                .Include(o => o.Renter)
+                                .OrderByDescending(o => o.CreatedAt)
+                                .ToListAsync();
+                }
 
 		public async Task<Order?> GetByIdAsync(int id)
 		{

--- a/LaptopRentalManagement/Pages/User/Lease-order/Index.cshtml
+++ b/LaptopRentalManagement/Pages/User/Lease-order/Index.cshtml
@@ -22,6 +22,32 @@
 			<!-- Order Status -->
 			<div class="col-md-9">
                                 <h3 class="mb-4">Your Lease Order</h3>
+                                <ul class="nav nav-tabs mb-3">
+                                    <li class="nav-item">
+                                        <a class="nav-link @(string.IsNullOrEmpty(Model.Status) ? "active" : "")" href="/user/lease-order">All</a>
+                                    </li>
+                                    <li class="nav-item">
+                                        <a class="nav-link @(Model.Status == "Unpaid" ? "active" : "")" href="/user/lease-order?status=Unpaid">Unpaid</a>
+                                    </li>
+                                    <li class="nav-item">
+                                        <a class="nav-link @(Model.Status == "Pending" ? "active" : "")" href="/user/lease-order?status=Pending">Pending</a>
+                                    </li>
+                                    <li class="nav-item">
+                                        <a class="nav-link @(Model.Status == "Approved" ? "active" : "")" href="/user/lease-order?status=Approved">Approved</a>
+                                    </li>
+                                    <li class="nav-item">
+                                        <a class="nav-link @(Model.Status == "Delivering" ? "active" : "")" href="/user/lease-order?status=Delivering">Delivering</a>
+                                    </li>
+                                    <li class="nav-item">
+                                        <a class="nav-link @(Model.Status == "Renting" ? "active" : "")" href="/user/lease-order?status=Renting">Renting</a>
+                                    </li>
+                                    <li class="nav-item">
+                                        <a class="nav-link @(Model.Status == "Completed" ? "active" : "")" href="/user/lease-order?status=Completed">Completed</a>
+                                    </li>
+                                    <li class="nav-item">
+                                        <a class="nav-link @(Model.Status == "Cancelled" ? "active" : "")" href="/user/lease-order?status=Cancelled">Cancelled</a>
+                                    </li>
+                                </ul>
                                 <div class="alert alert-info" role="alert">
                                     Total Earnings (Completed Orders):
                                     <strong>@Model.TotalRevenue.ToString("N0")₫</strong>

--- a/LaptopRentalManagement/Pages/User/Lease-order/Index.cshtml.cs
+++ b/LaptopRentalManagement/Pages/User/Lease-order/Index.cshtml.cs
@@ -21,6 +21,10 @@ namespace LaptopRentalManagement.Pages.User.Lease_order
         public IList<OrderResponse> MyLeaseOrder { get; set; } = new List<OrderResponse>();
 
         public decimal TotalRevenue { get; set; }
+
+        [BindProperty(SupportsGet = true)]
+        public string? Status { get; set; }
+
         public async Task<IActionResult> OnGet()
         {
             var userIdClaim = User.FindFirstValue(ClaimTypes.NameIdentifier) ?? User.FindFirstValue("AccountId");
@@ -31,7 +35,8 @@ namespace LaptopRentalManagement.Pages.User.Lease_order
             }
             OrderFilter orderFilter = new()
             {
-                OwnerId = int.Parse(userIdClaim)
+                OwnerId = int.Parse(userIdClaim),
+                Status = Status
             };
 
             MyLeaseOrder = await _orderService.GetAllAsync(orderFilter);

--- a/LaptopRentalManagement/Pages/User/Rental-order/Index.cshtml
+++ b/LaptopRentalManagement/Pages/User/Rental-order/Index.cshtml
@@ -19,7 +19,33 @@
 		{
 			<!-- Order Status -->
 			<div class="col-md-9">
-				<h3 class="mb-4">Your Rental Order</h3>
+                                <h3 class="mb-4">Your Rental Order</h3>
+                                <ul class="nav nav-tabs mb-3">
+                                    <li class="nav-item">
+                                        <a class="nav-link @(string.IsNullOrEmpty(Model.Status) ? "active" : "")" href="/user/rental-order">All</a>
+                                    </li>
+                                    <li class="nav-item">
+                                        <a class="nav-link @(Model.Status == "Unpaid" ? "active" : "")" href="/user/rental-order?status=Unpaid">Unpaid</a>
+                                    </li>
+                                    <li class="nav-item">
+                                        <a class="nav-link @(Model.Status == "Pending" ? "active" : "")" href="/user/rental-order?status=Pending">Pending</a>
+                                    </li>
+                                    <li class="nav-item">
+                                        <a class="nav-link @(Model.Status == "Approved" ? "active" : "")" href="/user/rental-order?status=Approved">Approved</a>
+                                    </li>
+                                    <li class="nav-item">
+                                        <a class="nav-link @(Model.Status == "Delivering" ? "active" : "")" href="/user/rental-order?status=Delivering">Delivering</a>
+                                    </li>
+                                    <li class="nav-item">
+                                        <a class="nav-link @(Model.Status == "Renting" ? "active" : "")" href="/user/rental-order?status=Renting">Renting</a>
+                                    </li>
+                                    <li class="nav-item">
+                                        <a class="nav-link @(Model.Status == "Completed" ? "active" : "")" href="/user/rental-order?status=Completed">Completed</a>
+                                    </li>
+                                    <li class="nav-item">
+                                        <a class="nav-link @(Model.Status == "Cancelled" ? "active" : "")" href="/user/rental-order?status=Cancelled">Cancelled</a>
+                                    </li>
+                                </ul>
 
 				<!-- Button trigger modal -->
 				<div class="tab-pane fade show active" id="buy-tab-pane" role="tabpanel">

--- a/LaptopRentalManagement/Pages/User/Rental-order/Index.cshtml.cs
+++ b/LaptopRentalManagement/Pages/User/Rental-order/Index.cshtml.cs
@@ -18,9 +18,13 @@ namespace LaptopRentalManagement.Pages.User.Rental_order
 		{
 			_orderService = orderService;
 		}
-		public IList<OrderResponse> MyRentalOrder { get; set; } = new List<OrderResponse>();
-		public async Task<IActionResult> OnGet()
-		{
+                public IList<OrderResponse> MyRentalOrder { get; set; } = new List<OrderResponse>();
+
+                [BindProperty(SupportsGet = true)]
+                public string? Status { get; set; }
+
+                public async Task<IActionResult> OnGet()
+                {
             var userIdClaim = User.FindFirstValue(ClaimTypes.NameIdentifier) ?? User.FindFirstValue("AccountId");
             if (!int.TryParse(userIdClaim, out var userId))
             {
@@ -28,8 +32,9 @@ namespace LaptopRentalManagement.Pages.User.Rental_order
                 return RedirectToPage("/Account/Login");
             }
             OrderFilter orderFilter = new()
-			{
-				RenterId = int.Parse(userIdClaim),
+                        {
+                                RenterId = int.Parse(userIdClaim),
+                                Status = Status,
             };
 
 			MyRentalOrder = await _orderService.GetAllAsync(orderFilter);


### PR DESCRIPTION
## Summary
- sort orders by `CreatedAt`
- add status filter tabs to lease-order and rental-order pages
- enable filtering by status via query parameter

## Testing
- `apt-get update` *(fails: Invalid response from proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6888a3544ef483208b6757b8278db8b4