### PR TITLE
Add refund support for rejected orders

### DIFF
--- a/LaptopRentalManagement.BLL/Interfaces/IZaloPayService.cs
+++ b/LaptopRentalManagement.BLL/Interfaces/IZaloPayService.cs
@@ -1,5 +1,6 @@
 using LaptopRentalManagement.DAL.Entities;
 using LaptopRentalManagement.Model.DTOs.Response.Order;
+using LaptopRentalManagement.Model.DTOs.Response.Refund;
 using Microsoft.AspNetCore.Http;
 
 namespace LaptopRentalManagement.BLL.Interfaces;
@@ -7,6 +8,7 @@ namespace LaptopRentalManagement.BLL.Interfaces;
 public interface IZaloPayService
 {
     Task<ZaloPayCreateOrderResponse> GetPymentUrl(long amount, Order order, string redirectUrl);
+    Task<ZaloPayRefundResponse> RefundAsync(string zpTransId, long amount, string description);
     bool VerifyCallback(IQueryCollection query);
     bool VerifyRedirect(IQueryCollection query);
 }

--- a/LaptopRentalManagement.Model/DTOs/Request/ZaloPayRefundRequest.cs
+++ b/LaptopRentalManagement.Model/DTOs/Request/ZaloPayRefundRequest.cs
@@ -1,0 +1,30 @@
+using System.Text.Json.Serialization;
+
+namespace LaptopRentalManagement.Model.DTOs.Request;
+
+public class ZaloPayRefundRequest
+{
+    [JsonPropertyName("app_id")]
+    public int AppId { get; set; }
+
+    [JsonPropertyName("zp_trans_id")]
+    public string ZpTransId { get; set; } = string.Empty;
+
+    [JsonPropertyName("amount")]
+    public long Amount { get; set; }
+
+    [JsonPropertyName("description")]
+    public string Description { get; set; } = string.Empty;
+
+    [JsonPropertyName("timestamp")]
+    public long Timestamp { get; set; }
+
+    [JsonPropertyName("mac")]
+    public string Mac { get; set; } = string.Empty;
+
+    public void MakeSignature(string key)
+    {
+        var data = $"{AppId}|{ZpTransId}|{Amount}|{Description}|{Timestamp}";
+        Mac = LaptopRentalManagement.Model.Helpers.HmacHelper.Compute(key, data);
+    }
+}

--- a/LaptopRentalManagement.Model/DTOs/Response/Refund/ZaloPayRefundResponse.cs
+++ b/LaptopRentalManagement.Model/DTOs/Response/Refund/ZaloPayRefundResponse.cs
@@ -1,0 +1,12 @@
+using Newtonsoft.Json;
+
+namespace LaptopRentalManagement.Model.DTOs.Response.Refund;
+
+public class ZaloPayRefundResponse
+{
+    [JsonProperty("return_code")]
+    public int ReturnCode { get; set; }
+
+    [JsonProperty("return_message")]
+    public string ReturnMessage { get; set; } = string.Empty;
+}

--- a/LaptopRentalManagement/appsettings.json
+++ b/LaptopRentalManagement/appsettings.json
@@ -10,6 +10,7 @@
     "Key1": "sdngKKJmqEMzvh5QQcdD2A9XBSKUNaYn",
     "Key2": "trMrHtvjo6myautxDUiAcYsVtaeQ8nhf",
     "CreateOrderUrl": "https://sb-openapi.zalopay.vn/v2/create",
-    "GetStatusUrl": "https://sb-openapi.zalopay.vn/v2/query"
+    "GetStatusUrl": "https://sb-openapi.zalopay.vn/v2/query",
+    "RefundUrl": "https://sb-openapi.zalopay.vn/v2/refund"
   }
 }


### PR DESCRIPTION
## Summary
- extend ZaloPay service interface to support refunds
- implement refund logic in ZaloPayService
- refund ZaloPay payment when an order is rejected
- wire IZaloPayService into OrderService
- add ZaloPay refund endpoint in appsettings

## Testing
- `dotnet build LaptopRentalManagement.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6888a6a5f00c83208db2309b5ee276ad