### PR TITLE
Handle canceled state in progress bar

### DIFF
--- a/LaptopRentalManagement/Pages/User/Lease-order/Detail.cshtml
+++ b/LaptopRentalManagement/Pages/User/Lease-order/Detail.cshtml
@@ -24,6 +24,8 @@
                 "Cancelled" => 7,
                 _ => 0
         };
+
+        var isCancelled = status == "Cancelled";
 }
 
 
@@ -113,43 +115,43 @@
 			</div>
                         <div class="stepper">
                                 <!-- Step 1: Unpaid -->
-                                <div class="step @(currentStep > 1 ? "complete" : currentStep == 1 ? "active" : "upcoming")">
+                                <div class="step @(isCancelled ? "upcoming" : currentStep > 1 ? "complete" : currentStep == 1 ? "active" : "upcoming")">
                                         <div class="circle">1</div>
                                         <div class="step-label">Unpaid</div>
                                 </div>
 
                                 <!-- Step 2: Pending -->
-                                <div class="step @(currentStep > 2 ? "complete" : currentStep == 2 ? "active" : "upcoming")">
+                                <div class="step @(isCancelled ? "upcoming" : currentStep > 2 ? "complete" : currentStep == 2 ? "active" : "upcoming")">
                                         <div class="circle">2</div>
                                         <div class="step-label">Pending</div>
                                 </div>
 
                                 <!-- Step 3: Approved -->
-                                <div class="step @(currentStep > 3 ? "complete" : currentStep == 3 ? "active" : "upcoming")">
+                                <div class="step @(isCancelled ? "upcoming" : currentStep > 3 ? "complete" : currentStep == 3 ? "active" : "upcoming")">
                                         <div class="circle">3</div>
                                         <div class="step-label">Approved</div>
                                 </div>
 
                                 <!-- Step 4: Delivering -->
-                                <div class="step @(currentStep > 4 ? "complete" : currentStep == 4 ? "active" : "upcoming")">
+                                <div class="step @(isCancelled ? "upcoming" : currentStep > 4 ? "complete" : currentStep == 4 ? "active" : "upcoming")">
                                         <div class="circle">4</div>
                                         <div class="step-label">Delivering</div>
                                 </div>
 
                                 <!-- Step 5: Renting -->
-                                <div class="step @(currentStep > 5 ? "complete" : currentStep == 5 ? "active" : "upcoming")">
+                                <div class="step @(isCancelled ? "upcoming" : currentStep > 5 ? "complete" : currentStep == 5 ? "active" : "upcoming")">
                                         <div class="circle">5</div>
                                         <div class="step-label">Renting</div>
                                 </div>
 
                                 <!-- Step 6: Complete -->
-                                <div class="step @(currentStep > 6 ? "complete" : currentStep == 6 ? "active" : "upcoming")">
+                                <div class="step @(isCancelled ? "upcoming" : currentStep > 6 ? "complete" : currentStep == 6 ? "active" : "upcoming")">
                                         <div class="circle">6</div>
                                         <div class="step-label">Complete</div>
                                 </div>
 
                                 <!-- Step 7: Cancelled -->
-                                <div class="step @(currentStep == 7 ? "active" : "upcoming")">
+                                <div class="step @(isCancelled ? "cancelled" : currentStep == 7 ? "active" : "upcoming")">
                                         <div class="circle">7</div>
                                         <div class="step-label">Cancelled</div>
                                 </div>

--- a/LaptopRentalManagement/Pages/User/Rental-order/Detail.cshtml
+++ b/LaptopRentalManagement/Pages/User/Rental-order/Detail.cshtml
@@ -24,6 +24,8 @@
                 "Cancelled" => 7,
                 _ => 0
         };
+
+        var isCancelled = status == "Cancelled";
 }
 
 
@@ -70,43 +72,43 @@
 			</div>
                         <div class="stepper">
                                 <!-- Step 1: Unpaid -->
-                                <div class="step @(currentStep > 1 ? "complete" : currentStep == 1 ? "active" : "upcoming")">
+                                <div class="step @(isCancelled ? "upcoming" : currentStep > 1 ? "complete" : currentStep == 1 ? "active" : "upcoming")">
                                         <div class="circle">1</div>
                                         <div class="step-label">Unpaid</div>
                                 </div>
 
                                 <!-- Step 2: Pending -->
-                                <div class="step @(currentStep > 2 ? "complete" : currentStep == 2 ? "active" : "upcoming")">
+                                <div class="step @(isCancelled ? "upcoming" : currentStep > 2 ? "complete" : currentStep == 2 ? "active" : "upcoming")">
                                         <div class="circle">2</div>
                                         <div class="step-label">Pending</div>
                                 </div>
 
                                 <!-- Step 3: Approved -->
-                                <div class="step @(currentStep > 3 ? "complete" : currentStep == 3 ? "active" : "upcoming")">
+                                <div class="step @(isCancelled ? "upcoming" : currentStep > 3 ? "complete" : currentStep == 3 ? "active" : "upcoming")">
                                         <div class="circle">3</div>
                                         <div class="step-label">Approved</div>
                                 </div>
 
                                 <!-- Step 4: Delivering -->
-                                <div class="step @(currentStep > 4 ? "complete" : currentStep == 4 ? "active" : "upcoming")">
+                                <div class="step @(isCancelled ? "upcoming" : currentStep > 4 ? "complete" : currentStep == 4 ? "active" : "upcoming")">
                                         <div class="circle">4</div>
                                         <div class="step-label">Delivering</div>
                                 </div>
 
                                 <!-- Step 5: Renting -->
-                                <div class="step @(currentStep > 5 ? "complete" : currentStep == 5 ? "active" : "upcoming")">
+                                <div class="step @(isCancelled ? "upcoming" : currentStep > 5 ? "complete" : currentStep == 5 ? "active" : "upcoming")">
                                         <div class="circle">5</div>
                                         <div class="step-label">Renting</div>
                                 </div>
 
                                 <!-- Step 6: Complete -->
-                                <div class="step @(currentStep > 6 ? "complete" : currentStep == 6 ? "active" : "upcoming")">
+                                <div class="step @(isCancelled ? "upcoming" : currentStep > 6 ? "complete" : currentStep == 6 ? "active" : "upcoming")">
                                         <div class="circle">6</div>
                                         <div class="step-label">Complete</div>
                                 </div>
 
                                 <!-- Step 7: Cancelled -->
-                                <div class="step @(currentStep == 7 ? "active" : "upcoming")">
+                                <div class="step @(isCancelled ? "cancelled" : currentStep == 7 ? "active" : "upcoming")">
                                         <div class="circle">7</div>
                                         <div class="step-label">Cancelled</div>
                                 </div>

--- a/LaptopRentalManagement/wwwroot/css/order-progress.css
+++ b/LaptopRentalManagement/wwwroot/css/order-progress.css
@@ -46,6 +46,10 @@
         background-color: #adb5bd;
     }
 
+    .step.cancelled .circle {
+        background-color: #dc3545;
+    }
+
 .step-label {
     margin-top: 0.5rem;
     font-size: 0.95rem;


### PR DESCRIPTION
## Summary
- add cancelled state style to progress bar
- show cancelled progress step in red and don't mark earlier steps complete

## Testing
- `dotnet build LaptopRentalManagement.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888b263c03c8320a87a9d16743df6c5